### PR TITLE
updated example of ThermoDataEstimator. 

### DIFF
--- a/examples/ThermoDataEstimator/input.txt
+++ b/examples/ThermoDataEstimator/input.txt
@@ -1,5 +1,14 @@
 Database: RMG_database
 
+//QM? true/false
+false
+//method: both/gaussian03/mopac/mm4/mm4hr 
+gaussian03
+//ForCyclicsOnly? true/false
+true
+//maxradnumforQM?
+0
+
 PrimaryThermoLibrary:
 Name: RMG-minimal
 Location: primaryThermoLibrary


### PR DESCRIPTION
The input file in the /examples/ThermoDataEstimator/ folder
for the TDE now includes a section with flags for
the on-the-fly generation of thermodynamic properties:

-a QM flag: true/false: activate on-the-fly thermo
-a method: both/gaussian03/mopac/mm4/mm4hr
-ForCyclicsOnly flag: use QM only for cyclic species
-MaxRadNumForQM fag: use QM only for species with a maximum
number of unpaired electrons. (usually, set to 0, to prevent
radicals from being calculated on-the-fly)

Closes #198
