### PR TITLE
aromaticity perception improvement for cyclics containingCdd atoms

### DIFF
--- a/source/RMG/jing/chem/ChemGraph.java
+++ b/source/RMG/jing/chem/ChemGraph.java
@@ -163,9 +163,37 @@ public class ChemGraph implements Matchable {
                     else if (!a.isRadical()) {
                         Iterator neighbors = ((Node)gc).getNeighbor();
                         int usedValency = 0;
+                        /*
+                         * We count here the number of double bonds attached to a particular 
+                         * atom. 
+                         * 
+                         * We do this because we don't want that species with a 
+                         * Cdd type carbon atom, i.e. carbon bonded by two double bonds,
+                         * is identified as being aromatic.
+                         * 
+                         * Previously, a five-membered cyclic species, containing
+                         * three double bonds with one Cdd carbon, would be perceived
+                         * as aromatic since 3*2 = 6 "Pi" electrons were counted, 
+                         * and a cyclic structure was present.
+                         * 
+                         * This patch, albeit not very general, counts the total
+                         * number of double bonds for a particular atom. If a second
+                         * double bond is detected, the pi-electron counter is not updated
+                         * by  adding two.
+                         * 
+                         * This makes at least some chemical sence, as you could 
+                         * argue that the second pair electrons in the pi-bonds (perpendicular to the other
+                         * pair of electrons) does not interact and conjugate with the
+                         * pi electrons of other electrons.
+                         *  
+                         */
+                        int number_of_double_bonds = 0;
                         while (neighbors.hasNext()) {
                             Arc nodeA= (Arc)neighbors.next();
-                            usedValency += ((Bond)(nodeA.getElement())).getOrder();
+                            double order = ((Bond)(nodeA.getElement())).getOrder();
+                            if(order==2) number_of_double_bonds++;
+                            if(number_of_double_bonds != 2)
+                            	usedValency += ((Bond)(nodeA.getElement())).getOrder();
                         }
                         if (a.getChemElement().getValency()-usedValency >= 2) {
                             piElectronsInCycle += 2;


### PR DESCRIPTION
The aromaticity perception algorithm would count two pairs of pi electrons
for a Cdd carbon atom, ie a tetravalent carbon atom bound by two double
bonds. A Cdd carbon would thus add 4 pi-electrons and particular molecules
with a Cdd atom in a cycle could be perceived as aromatic.

Since it can be argued that these molecules with sp hybridized orbitals
are at least an ambiguous class of compounds in terms of aromaticity,
it is opted not to match these species as being aromatic.

this is accomplished by counting the number of double bonds attached
to each carbon. If a second double bond per atom is detected, the
pi electron counter is not updated (by adding 2). Therefore, molecules
such as InChI=1S/C5H4/c1-2-4-5-3-1/h1-4H are not aromatic.

On top of that, the aromaticity perception would also induce an error
in terms of hydrogen counting since implicit hydrogens can be added
by RMG a posteriori. A "Cdd" carbon, having no available bonds for a hydrogen
would be perceived as "Cb", connected to carbons by a single and a
double bond. The hydrogen adder would add a hydrogen, and provoke
element balance errors in the Structure class (where element balances are
checked).

This patch is very problem-specific (to Cdd atoms), and thus limited in
applicability.

More generalized improvements to the aromaticity perception algorithm
could be of use, especially with the addition of hetero-elements and re-
percussions on aromaticity in mind (cf. thiophene, furane, pyrole)

thanks to @gmagoon for helpful discussions!
