### PR TITLE
bug fix for aromatics perception of triple bond species

### DIFF
--- a/source/RMG/jing/chem/ChemGraph.java
+++ b/source/RMG/jing/chem/ChemGraph.java
@@ -202,10 +202,26 @@ public class ChemGraph implements Matchable {
                     }
                 } else if (gc instanceof Arc) {
                     Bond b = (Bond)((Arc)gc).getElement();
-                    int bondPiElectrons = b.getPiElectrons();
-                    if (bondPiElectrons > 0) {
-                        piElectronsInCycle += bondPiElectrons;
-                        hadPiElectrons[numComps] = true;
+                    /*
+                     * For now, species with a triple bond conjugated to two double bonds
+                     * would also contribute to the pi electron count. Hence, molecules
+                     * such as benzyne (InChI=1S/C6H4/c1-2-4-6-5-3-1/h1-4H) would
+                     * have a hueckel number of 6 and would then be perceived as aromatic.
+                     * 
+                     *  The atomtype of the triple bonded carbons (Ct) would be changed
+                     *  to Cb and hence an atom would be added afterwards, in a place
+                     *  where that would not possible.
+                     *  
+                     *  In order to avoid this problem, an if conditional is added that 
+                     *  checks whether the iterated bond is a double bond. If not,
+                     *  contributions to the pi electron count are not taken into account.
+                     */
+                    if(b.getOrder() == 2){
+                        int bondPiElectrons = b.getPiElectrons();
+                        if (bondPiElectrons > 0) {
+                            piElectronsInCycle += bondPiElectrons;
+                            hadPiElectrons[numComps] = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
species like benzyne (InChI=1S/C6H4/c1-2-4-6-5-3-1/h1-4H0)
with a triple bond instead of a double bond in a cyclic conjugated
system would also be perceived as aromatic since the triple
bond contributes 2 pi electrons (like a double bond) and a
Hueckel number could thus be matched.

The algorithm would then change the atom type of these triple
bonded carbons (Ct) to Cb. And this is where it goes wrong: the
hydrogen adder will note that the created Cb atom does not bear
a hydrogen. thus, it will add one. Since the Ct carbon in e.g.
benzyne cannot bear an extra hydrogen, this will create an
error that perpetuates to other places in RMG.

Therefore, the temporary solution here is to perceive benzyne type
species as NOT aromatic so that a hydrogen atom is not added afterwards.

This is done when iterating over the bonds by checking if the bond type
is double. Only in that case, the pi electron counter is updated.
