### PR TITLE
bug fix for aromatics perception: implicit hydrogens

### DIFF
--- a/source/RMG/jing/chem/ChemGraph.java
+++ b/source/RMG/jing/chem/ChemGraph.java
@@ -143,6 +143,7 @@ public class ChemGraph implements Matchable {
     }
 
     public void determineAromaticityAndWriteBBonds() {
+    	addMissingHydrogen();
         // If there are no cycles, cannot be aromatic
         if (graph.getCycleNumber() == 0) return;
         // Check each cycle for aromaticity


### PR DESCRIPTION
in case one does not define the explicit hydrogens in an adjacency
list, the aromatics perception algo wrongly calculates the
'used_valency' counter.

Now, the addMissingHydrogen() method is called at the beginning
of the algorithm to make sure all hydrogens are explicit.

This bug was found by the case of the five membered ring species
(InChI=1S/C5H5/c1-2-4-5-3-1/h1-2,5H,3H2) containing an sp3 hybridized
carbon without explicit hydrogens. Because this carbon only had
two as the value of used_valency, it contributed two to the pi-electron
count, turning this non-aromatic species into an aromatic one.

Again, the Cs atom would turn into an Cb atom and only one explicit
hydrogen would be added instead of two. So here the aromatics perception
algorithm wrongly removes a hydrogen instead of wrongly adding one
for Cdd or Ct atoms.
