### PR TITLE
removed unused, and deprecated import statement

### DIFF
--- a/source/RMG/jing/chem/ThermoData.java
+++ b/source/RMG/jing/chem/ThermoData.java
@@ -33,8 +33,6 @@ package jing.chem;
 
 import java.util.*;
 
-import com.sun.org.apache.xpath.internal.operations.Plus;
-
 import jing.param.*;
 
 //## package jing::chem


### PR DESCRIPTION
the import from the sun API was deprecated, but not used anymore
in ThermoData type.
