### PR TITLE
number of plog rates written to pdepnetworks set to fame default

### DIFF
--- a/source/RMG/jing/rxnSys/ReactionModelGenerator.java
+++ b/source/RMG/jing/rxnSys/ReactionModelGenerator.java
@@ -2778,7 +2778,8 @@ public class ReactionModelGenerator {
     		bw.newLine();
     		bw.write("NumberOfChebyPress: " + numChebyPress);
     		bw.newLine();
-    		bw.write("NumberOfPLogs: Could be different for seed and library reactions, but default for FAME-generated rates is probably "+ numPlog);
+    		//Could be different for seed and library reactions, but default for FAME-generated rates is probably 
+    		bw.write("NumberOfPLogs: "+ numPlog);
     		bw.newLine();
     		bw.newLine();
     		


### PR DESCRIPTION
For now, the phrase
"Could be different for seed and library reactions,
but default for FAME-generated rates is probably "

that was written to pdepnetworks.txt in the restart folder is replaced
by the FAME default number of PLOGS.

WARNING: this is a temporary solution that (almost) certainly
 works in absence of seed mechanisms and PKLs, PRLs but certainly
fails in presence of the latter. Check Github issue threads for more
information.

Tested successfully on the 1,3-Hexadiene example.
